### PR TITLE
add header for intel channel extension with aoc 19

### DIFF
--- a/include/utils/ocl_utils.hpp
+++ b/include/utils/ocl_utils.hpp
@@ -17,6 +17,7 @@
 #include <unistd.h>
 
 #include "CL/cl.hpp"
+#include "CL/cl_ext_intelfpga"
 
 /**
  * @brief The IntelFPGAOCLUtils class contains a set of basic utilities for interacting

--- a/include/utils/ocl_utils.hpp
+++ b/include/utils/ocl_utils.hpp
@@ -8,7 +8,6 @@
   Author: Tiziano De Matteis
 */
 
-
 #ifndef OCL_UTILS_HPP
 #define OCL_UTILS_HPP
 #include <string>
@@ -17,7 +16,9 @@
 #include <unistd.h>
 
 #include "CL/cl.hpp"
+#ifndef CL_CHANNEL_1_INTELFPGA
 #include "CL/cl_ext_intelfpga.h"
+#endif
 
 /**
  * @brief The IntelFPGAOCLUtils class contains a set of basic utilities for interacting

--- a/include/utils/ocl_utils.hpp
+++ b/include/utils/ocl_utils.hpp
@@ -8,6 +8,7 @@
   Author: Tiziano De Matteis
 */
 
+
 #ifndef OCL_UTILS_HPP
 #define OCL_UTILS_HPP
 #include <string>
@@ -16,7 +17,8 @@
 #include <unistd.h>
 
 #include "CL/cl.hpp"
-#ifndef CL_CHANNEL_1_INTELFPGA
+#if !defined(CL_CHANNEL_1_INTELFPGA)
+// include this header if channel macros are not defined in cl.hpp (versions >=19.0)
 #include "CL/cl_ext_intelfpga.h"
 #endif
 

--- a/include/utils/ocl_utils.hpp
+++ b/include/utils/ocl_utils.hpp
@@ -17,7 +17,7 @@
 #include <unistd.h>
 
 #include "CL/cl.hpp"
-#include "CL/cl_ext_intelfpga"
+#include "CL/cl_ext_intelfpga.h"
 
 /**
  * @brief The IntelFPGAOCLUtils class contains a set of basic utilities for interacting


### PR DESCRIPTION
This PR adds an additional header to use CL_CHANNEL_*_INTELFPGA extension with Intel FPGA SDK for OpenCL 19.
